### PR TITLE
Update 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1](https://github.com/poetter-sebastian/SimpleThenticator/releases/tag/1.1) (2025-09-06)
+
+- Dropped PHP 8.1 from supported versions
+- Fixed phpunit.xml of PHPUnit 12
+
 ## [1.0.1](https://github.com/poetter-sebastian/SimpleThenticator/releases/tag/1.0.1) (2025-06-04)
 
 - Update README.md by @poetter-sebastian in https://github.com/poetter-sebastian/SimpleThenticator/pull/6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.2](https://github.com/poetter-sebastian/SimpleThenticator/releases/tag/1.2) (2026-02-14)
+- Enhanced unit tests with additional boundary condition testing
+- Added tests for maximum code length validation
+- Added tests for maximum secret length validation
+- Added edge case testing for time slice boundary conditions
+- Added comprehensive testing for timing-safe comparison with long strings
+- Added tests for code length consistency across different hash algorithms
+- Added tests for all supported hash algorithms
+- Fixed validation of code and secret length parameters
+- Removed doubled tests
+- deprecated getAlgorithm() function
+
 ## [1.1.1](https://github.com/poetter-sebastian/SimpleThenticator/releases/tag/1.1.1) (2025-09-17)
 
 - Fixed compatibility issues of PHP 8.2 with newer features of PHP 8.4 (thanks for reporting it @ejellard in #12)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=8.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5.36"
+        "phpunit/phpunit": "^11.5.53"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7db2fd7b47d9ac551150d04c609ab308",
+    "content-hash": "ed2a8ea9224e68de262ce6911d4a0b76",
     "packages": [],
     "packages-dev": [
         {
@@ -69,16 +69,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -121,9 +121,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -245,35 +245,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.11",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.4.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.2",
                 "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-text-template": "^4.0.1",
                 "sebastian/code-unit-reverse-lookup": "^4.0.1",
                 "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.0",
+                "sebastian/environment": "^7.2.1",
                 "sebastian/lines-of-code": "^3.0.1",
                 "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.2"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -311,7 +311,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
@@ -331,32 +331,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T14:37:49+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -384,15 +384,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T05:02:59+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -580,16 +592,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.36",
+            "version": "11.5.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "264a87c7ef68b1ab9af7172357740dc266df5957"
+                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/264a87c7ef68b1ab9af7172357740dc266df5957",
-                "reference": "264a87c7ef68b1ab9af7172357740dc266df5957",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a997a653a82845f1240d73ee73a8a4e97e4b0607",
+                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607",
                 "shasum": ""
             },
             "require": {
@@ -603,19 +615,20 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.11",
-                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.2",
+                "sebastian/comparator": "^6.3.3",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.0",
+                "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -661,7 +674,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.36"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.53"
             },
             "funding": [
                 {
@@ -685,7 +698,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-03T06:24:17+00:00"
+            "time": "2026-02-10T12:28:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -859,16 +872,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.2",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85c77556683e6eee4323e4c5468641ca0237e2e8",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
@@ -927,7 +940,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -947,7 +960,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T08:07:46+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1152,16 +1165,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.0",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/3473f61172093b2da7de1fb5782e1f24cc036dc3",
-                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
@@ -1175,7 +1188,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -1218,15 +1231,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T09:17:50+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1715,16 +1740,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1778,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -1761,7 +1786,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/SimpleAuthenticator.php
+++ b/src/SimpleAuthenticator.php
@@ -13,7 +13,7 @@ use ValueError;
  *
  * @package  sebastian/simplethenticator
  * @author   Sebatian Pötter
- * @version  1.1
+ * @version  1.2
  * @access   public
  * @see      https://github.com/poetter-sebastian/SimpleThenticator
  */
@@ -23,43 +23,66 @@ class SimpleAuthenticator
     private string $alg;
 
     /**
-     * @param int|null $codeLength
-     * @param string|null $usedAlg
-     * @throws Exception
+     * @param int|null $codeLength Length between 6 and 10
+     * @param string|null $usedAlg Used hash algorithm 'SHA1', 'SHA256', 'SHA512'
+     * @throws Exception throws ValueError exception if $codeLength is smaller or grater then 10 or if the hash algorithm is not supported
      */
     public function __construct(?int $codeLength = 6, ?string $usedAlg = 'SHA256')
     {
         $this->codeLength = $codeLength ?? 6;
         $this->alg = $usedAlg ?? 'SHA256';
 
+        if (!in_array($this->alg, self::supportedHashAlgorithms(), true)) {
+            throw new ValueError('Hash algorithm not allowed. Use one of: ' . implode(', ', self::supportedHashAlgorithms()));
+        }
+
         if($this->codeLength < 6)
         {
             throw new ValueError("Code is less then 6");
         }
 
-        if(!in_array(strtolower($this->alg), hash_hmac_algos()))
+        if($this->codeLength > 10)
         {
+            throw new ValueError("Code is higher then 10");
+        }
+
+        // this should never happen!
+        if(!in_array(strtolower($this->alg), hash_hmac_algos(), true))
+        {
+            // @codeCoverageIgnoreStart
             throw new ValueError("Hash function $this->alg is not supported by hash_hmac");
+            // @codeCoverageIgnoreEnd
         }
     }
 
+    /**
+     * Gets the current code length
+     * @return int
+     */
     public function GetCodeLength(): int
     {
         return $this->codeLength;
     }
 
-    public function GetUsedHasAlgorithm(): string
+    /**
+     * Gets the set code length
+     * @return string returns the current used hash algorithm
+     */
+    public function getUsedHasAlgorithm(): string
     {
         return $this->alg;
     }
 
     /**
-     * Gets the set code length
-     * @return string
+     * Returns the current used hash algorithm
+     * @return string returns the current used hash algorithm
+     * @deprecated will be removed in the next version
      */
     public function getAlgorithm(): string
     {
-        return $this->alg;
+        // @codeCoverageIgnoreStart
+        return $this->getUsedHasAlgorithm();
+        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -76,8 +99,8 @@ class SimpleAuthenticator
 
         $secretKey = self::base32Decode($secret);
 
-        // Pack time into a binary string
-        $time = chr(0) . chr(0) . chr(0) . chr(0) . pack('N*', $timeSlice);
+        // Pack time into an 8-byte binary string (high 32-bit zero for current-era counters and after 2030 time)
+        $time = pack('N2', 0, $timeSlice);
         // Hash it with users' secret key
         $hm = hash_hmac($this->alg, $time, $secretKey, true);
         // Use the last nipple of a result as index/offset
@@ -86,11 +109,9 @@ class SimpleAuthenticator
         $hashPart = substr($hm, $offset, 4);
 
         // Unpack binary value
-        $value = unpack('N', $hashPart);
-        $value = $value[1];
-        // Only 32 bits
-        $value = $value & 0x7FFFFFFF;
+        $value = unpack('N', $hashPart)[1] & 0x7FFFFFFF;
 
+        // With codeLength <= 10 this stays within the safe integer range
         $modulo = pow(10, $this->codeLength);
 
         return str_pad((string)($value % $modulo), $this->codeLength, '0', STR_PAD_LEFT);
@@ -164,7 +185,6 @@ class SimpleAuthenticator
      * Helper class to decode base32.
      *
      * @param $secret
-     *
      * @return string
      */
     protected function base32Decode($secret): string
@@ -299,6 +319,15 @@ class SimpleAuthenticator
             'Y', 'Z', '2', '3', '4', '5', '6', '7', // 31
             '=',  // padding char
         ];
+    }
+
+    /**
+     * RFC6238 algorithms only
+     * @return string[] Returns the RFC6238 algorithms
+     */
+    public static function supportedHashAlgorithms(): array
+    {
+        return ['SHA1', 'SHA256', 'SHA512'];
     }
 
     /**

--- a/tests/SimpleAuthenticatorTest.php
+++ b/tests/SimpleAuthenticatorTest.php
@@ -185,7 +185,7 @@ final class SimpleAuthenticatorTest extends TestCase
         $secret = 'SECRET';
 
         // Test with a very large time slice
-        $code = $auth->getCode($secret, PHP_INT_MAX);
+        $code = $auth->getCode($secret,  92233720368);
         $this->assertIsString($code);
         $this->assertGreaterThanOrEqual(0, strlen($code));
     }

--- a/tests/SimpleAuthenticatorTest.php
+++ b/tests/SimpleAuthenticatorTest.php
@@ -45,7 +45,6 @@ final class SimpleAuthenticatorTest extends TestCase
     public static function hashAlgorithmProvider(): array
     {
         return [
-            ['MD5'],
             ['SHA1'],
             ['SHA224'],
             ['SHA256'],
@@ -59,30 +58,9 @@ final class SimpleAuthenticatorTest extends TestCase
             ['SHA3-512'],
             ['RIPEMD160'],
             ['WHIRLPOOL'],
-            ['TIGER128,3'],
-            ['TIGER160,3'],
-            ['TIGER192,3'],
-            ['TIGER128,4'],
-            ['TIGER160,4'],
-            ['TIGER192,4'],
             ['SNEFRU'],
             ['SNEFRU256'],
             ['GOST'],
-            ['HAVAL128,3'],
-            ['HAVAL160,3'],
-            ['HAVAL192,3'],
-            ['HAVAL224,3'],
-            ['HAVAL256,3'],
-            ['HAVAL128,4'],
-            ['HAVAL160,4'],
-            ['HAVAL192,4'],
-            ['HAVAL224,4'],
-            ['HAVAL256,4'],
-            ['HAVAL128,5'],
-            ['HAVAL160,5'],
-            ['HAVAL192,5'],
-            ['HAVAL224,5'],
-            ['HAVAL256,5'],
         ];
     }
 
@@ -109,20 +87,12 @@ final class SimpleAuthenticatorTest extends TestCase
 
         ob_end_clean();
 
-        $this->assertTrue($auth->GetUsedHasAlgorithm() === 'SHA256');
+        $this->assertTrue($auth->getUsedHasAlgorithm() === 'SHA256');
         $this->assertTrue($auth->verifyCode($secret, $oneCode, 2));
     }
 
     /**
-     * @throws Exception
-     */
-    public function testConstructorWithOtherHashFunction()
-    {
-        $auth = new SimpleAuthenticator(0);
-        $secret = $auth->createSecret(0);
-    }
-
-    /**
+     * Tests if code length is too low
      * @throws Exception
      */
     public function testConstructorException()
@@ -133,6 +103,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Tests if secret is too low
      * @throws Exception
      */
     public function testCreateSecretTooLowSecret()
@@ -143,6 +114,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Tests if secret is too high
      * @throws Exception
      */
     public function testCreateSecretTooHighSecret()
@@ -153,27 +125,112 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test maximum code length validation
+     * @throws Exception
+     */
+    public function testMaximumCodeLengthValidation(): void
+    {
+        $this->expectException(ValueError::class);
+        $auth = new SimpleAuthenticator(11);
+    }
+
+    /**
+     * Test code generation with maximum length
+     * @throws Exception
+     */
+    public function testCodeGenerationWithMaximumLength(): void
+    {
+        $auth = new SimpleAuthenticator(10); // Maximum allowed length
+        $secret = $auth->createSecret();
+        $code = $auth->getCode($secret);
+        $this->assertEquals(10, strlen($code));
+    }
+
+    /**
+     * Test very long secret generation
+     */
+    public function testVeryLongSecretGeneration(): void
+    {
+        $auth = new SimpleAuthenticator();
+        $secret = $auth->createSecret(128); // Maximum allowed secret length
+        $this->assertEquals(128, strlen($secret));
+    }
+
+
+    /**
+     * Test boundary conditions for time slices
+     */
+    public function testTimeSliceBoundaryConditions(): void
+    {
+        $auth = new SimpleAuthenticator();
+        $secret = 'SECRET';
+
+        // Test with a valid time slice
+        $code = $auth->getCode($secret, 0);
+        $this->assertIsString($code);
+        $this->assertGreaterThanOrEqual(0, strlen($code));
+
+        // Test with a negative time slice
+        $code = $auth->getCode($secret, -100);
+        $this->assertIsString($code);
+    }
+
+
+    /**
+     * Test invalid time slice in getCode
+     */
+    public function testGetCodeWithInvalidTimeSlice(): void
+    {
+        $auth = new SimpleAuthenticator();
+        $secret = 'SECRET';
+
+        // Test with a very large time slice
+        $code = $auth->getCode($secret, PHP_INT_MAX);
+        $this->assertIsString($code);
+        $this->assertGreaterThanOrEqual(0, strlen($code));
+    }
+
+    /**
+     * Test null behavior
      * @throws Exception
      */
     public function testCreateSecretOnNull()
     {
         $auth = new SimpleAuthenticator(null);
         $this->assertEquals(6, $auth->GetCodeLength());
-        $this->assertEquals('SHA256', $auth->getAlgorithm());
+        $this->assertEquals('SHA256', $auth->getUsedHasAlgorithm());
 
         $auth = new SimpleAuthenticator(6, null);
         $this->assertEquals(6, $auth->GetCodeLength());
-        $this->assertEquals('SHA256', $auth->getAlgorithm());
+        $this->assertEquals('SHA256', $auth->getUsedHasAlgorithm());
     }
 
     /**
+     * Test edge case for timing safe equals with maximum string length
+     */
+    public function testTimingSafeEqualsWithMaximumStringLength(): void
+    {
+        $longString = str_repeat('A', 1000);
+        $this->assertTrue(SimpleAuthenticator::timingSafeEquals($longString, $longString));
+        $differentString = str_repeat('B', 1000);
+        $this->assertFalse(SimpleAuthenticator::timingSafeEquals($longString, $differentString));
+    }
+
+    /**
+     * Test only usable hash algorithm
      * @throws Exception
      */
     #[DataProvider('hashAlgorithmProvider')]
     public function testSupportedHashAlgorithm(string $algorithm)
     {
+        if (!in_array($algorithm, SimpleAuthenticator::supportedHashAlgorithms(), true)) {
+            $this->expectException(ValueError::class);
+            $auth = new SimpleAuthenticator(6, $algorithm);
+        }
+
         $auth = new SimpleAuthenticator(6, $algorithm);
-        $this->assertEquals($algorithm, $auth->GetUsedHasAlgorithm());
+
+        $this->assertEquals($algorithm, $auth->getUsedHasAlgorithm());
 
         $secret = 'SECRET';
         $code = $auth->getCode($secret);
@@ -183,6 +240,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test specific not existing hash algorithm
      * @throws Exception
      */
     public function testCreateSecretWithWrongHashFunction()
@@ -192,6 +250,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test default secret creation
      * @throws Exception
      */
     public function testCreateSecretDefaultsToSixteenCharacters()
@@ -203,6 +262,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test specified secret length
      * @throws Exception
      */
     public function testCreateSecretLengthCanBeSpecified()
@@ -217,7 +277,10 @@ final class SimpleAuthenticatorTest extends TestCase
         }
     }
 
-    #[DataProvider('codeProvider')] #[DataProvider('codeProvider')]
+    /**
+     * Test specified secret, time, and code combinations
+     */
+    #[DataProvider('codeProvider')]
     public function testGetCodeReturnsCorrectValues($secret, $timeSlice, $code)
     {
         $auth = new SimpleAuthenticator();
@@ -225,6 +288,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertEquals($code, $auth->getCode($secret, $timeSlice));
     }
 
+    /**
+     * Test URL generation behavior
+     */
     public function testGetQRCodeGoogleUrlReturnsCorrectUrl()
     {
         $auth = new SimpleAuthenticator();
@@ -245,6 +311,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertEquals($queryStringArray['data'], $expectedChl);
     }
 
+    /**
+     * Test default code verification
+     */
     public function testVerifyCode()
     {
         $auth = new SimpleAuthenticator();
@@ -261,6 +330,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * Test verification with a leading zero
+     */
     public function testVerifyCodeWithLeadingZero()
     {
         $auth = new SimpleAuthenticator();
@@ -275,6 +347,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * Test wrong code check
+     */
     public function testVerifyCodeWithWrongCode()
     {
         $auth = new SimpleAuthenticator();
@@ -285,6 +360,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * Test empty check
+     */
     public function testEmptySecret()
     {
         $auth = new SimpleAuthenticator();
@@ -295,6 +373,9 @@ final class SimpleAuthenticatorTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * Test too long code check
+     */
     public function testLongerUserKey()
     {
         $auth = new SimpleAuthenticator();
@@ -306,9 +387,10 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test optional parameters
      * Thanks to https://github.com/PHPGangsta/GoogleAuthenticator/pull/41
      */
-    #[DataProvider('paramsProvider')] #[DataProvider('paramsProvider')]
+    #[DataProvider('paramsProvider')]
     public function testGetQRCodeGoogleUrlReturnsCorrectUrlWithOptionalParameters($width, $height, $level, $expectedSize, $expectedLevel)
     {
         $auth = new SimpleAuthenticator();
@@ -329,6 +411,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder
      * @throws ReflectionException
      */
     public function testBase32DecodeWithValidSecret(): void
@@ -339,6 +422,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder on empty input
      * @throws ReflectionException
      */
     public function testBase32DecodeWithEmptySecret(): void
@@ -349,6 +433,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder with invalide characters
      * @throws ReflectionException
      */
     public function testBase32DecodeWithInvalidCharacters(): void
@@ -359,6 +444,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder with wrong padding
      * @throws ReflectionException
      */
     public function testBase32DecodeWithInvalidPaddingCount(): void
@@ -369,6 +455,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder with correct padding
      * @throws ReflectionException
      */
     public function testBase32DecodeWithPaddingCharacters(): void
@@ -465,6 +552,7 @@ final class SimpleAuthenticatorTest extends TestCase
     }
 
     /**
+     * Test base-32 decoder invocation
      * @throws ReflectionException
      */
     private function invokeBase32Decode(string $secret): string


### PR DESCRIPTION
- Added tests for all supported hash algorithms and edge cases
- Fixed validation of code and secret length parameters
- Removed doubled tests
- deprecated getAlgorithm() function